### PR TITLE
Fix: Selenium locate element error, specified version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-selenium
+selenium==4.2.0
 pandas
 python-dotenv
 chromedriver-autoinstaller


### PR DESCRIPTION
Following the steps in the ``README.md`` will install the latest version of Selenium which deprecated the `find_element_by_*` and `find_elements_by_*` in [version 4.3.0](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES)

gives: `
unable to locate element: {"method":"xpath","selector":"//input[@autocomplete="username"]"}
`

Changed the `requirements.txt` to specify Selenium version 4.2.0